### PR TITLE
feat: logging improvements

### DIFF
--- a/app/cli/cmd.go
+++ b/app/cli/cmd.go
@@ -17,7 +17,8 @@ import (
 )
 
 var (
-	verbose bool
+	verbose  bool
+	showTime bool
 )
 
 var exceptions = []string{
@@ -29,7 +30,10 @@ var Cmd = &cobra.Command{
 	Use:   "iac",
 	Short: "A custom, and perhaps over-engineered, IaC solution",
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-		logger.SetupLogger(verbose)
+		logger.SetupLogger(logger.LoggerOptions{
+			Verbose: verbose,
+			Time:    showTime,
+		})
 		slog.Debug("Logger setup complete", "verbose", verbose)
 		cmdName := cmd.Name()
 		if !slices.Contains(exceptions, cmdName) {
@@ -51,4 +55,5 @@ func init() {
 	Cmd.AddCommand(up.Cmd)
 	Cmd.AddCommand(version.Cmd)
 	Cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
+	Cmd.PersistentFlags().BoolVarP(&showTime, "show-time", "t", false, "Show timestamps in logs")
 }

--- a/app/main.go
+++ b/app/main.go
@@ -8,7 +8,10 @@ import (
 )
 
 func main() {
-	logger.SetupLogger(true)
+	logger.SetupLogger(logger.LoggerOptions{
+		Verbose: true,
+		Time:    false,
+	})
 	err := cli.Cmd.Execute()
 	if err != nil {
 		os.Exit(exitcodes.UnknownError)

--- a/app/utils/logger/setup.go
+++ b/app/utils/logger/setup.go
@@ -7,16 +7,35 @@ import (
 	"github.com/lmittmann/tint"
 )
 
-func SetupLogger(verbose bool) {
+type LoggerOptions struct {
+	Verbose bool
+	Time    bool
+}
+
+func SetupLogger(opts LoggerOptions) {
 	var level slog.Level
-	if verbose {
+	if opts.Verbose {
 		level = slog.LevelDebug
 	} else {
 		level = slog.LevelInfo
 	}
+
 	handlerOptions := tint.Options{
 		Level: level,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if !opts.Time && a.Key == slog.TimeKey && len(groups) == 0 {
+				return slog.Attr{}
+			}
+			if a.Key == slog.LevelKey {
+				level := a.Value.Any().(slog.Level)
+				if level == slog.LevelDebug {
+					return tint.Attr(244, a)
+				}
+			}
+			return a
+		},
 	}
+
 	handler := tint.NewHandler(os.Stdout, &handlerOptions)
 	logger := slog.New(handler)
 	slog.SetDefault(logger)


### PR DESCRIPTION
- timestamps are now disabled by default. use -t flag to show timestamps
- debug logs are now gray color
